### PR TITLE
Fixed character alignment remaining after disable

### DIFF
--- a/src/OTS-Camera/init.lua
+++ b/src/OTS-Camera/init.lua
@@ -137,6 +137,7 @@ local function configureStateForEnabled()
 end
 
 local function configureStateForDisabled()
+	OTS_Cam.SetCharacterAlignment(false)
 	loadDefaultCamera()
 	UserInputService.MouseBehavior = SavedMouseBehavior
 	OTS_Cam.HorizontalAngle = 0


### PR DESCRIPTION
When disabling the module after enabling it with IsCharacterAligned set to true, your character still remains aligned to the camera.